### PR TITLE
Update http library to 0.13.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  http: ^0.12.2
+  http: ^0.13.4
 
 dev_dependencies:
   pedantic: any


### PR DESCRIPTION
We need to upgrade `http` library to 0.13.x to use in some projects that `http` references is updated.
